### PR TITLE
Added MoMA subset

### DIFF
--- a/artworks_subset.json
+++ b/artworks_subset.json
@@ -1,0 +1,190 @@
+{
+    "Title": "L'Estaque",
+    "Artist": [
+      "Paul Cézanne"
+    ],
+    "ConstituentID": [
+      1053
+    ],
+    "ArtistBio": [
+      "French, 1839–1906"
+    ],
+    "Nationality": [
+      "French"
+    ],
+    "BeginDate": [
+      1839
+    ],
+    "EndDate": [
+      1906
+    ],
+    "Gender": [
+      "Male"
+    ],
+    "Date": "1879-83",
+    "Medium": "Oil on canvas",
+    "Dimensions": "31 1/2 x 39\" (80.3 x 99.4 cm)",
+    "CreditLine": "The William S. Paley Collection",
+    "AccessionNumber": "716.1959",
+    "Classification": "Painting",
+    "Department": "Painting & Sculpture",
+    "DateAcquired": "1959-12-30",
+    "Cataloged": "Y",
+    "ObjectID": 80302,
+    "URL": "http://www.moma.org/collection/works/80302",
+    "ThumbnailURL": "http://www.moma.org/media/W1siZiIsIjUxNjY3NyJdLFsicCIsImNvbnZlcnQiLCItcmVzaXplIDMwMHgzMDBcdTAwM2UiXV0.jpg?sha=5209b695d629f28b",
+    "Height (cm)": 80.3,
+    "Width (cm)": 99.4
+  },
+  {
+  "Title": "Water Lilies",
+  "Artist": [
+    "Claude Monet"
+  ],
+  "ConstituentID": [
+    4058
+  ],
+  "ArtistBio": [
+    "French, 1840–1926"
+  ],
+  "Nationality": [
+    "French"
+  ],
+  "BeginDate": [
+    1840
+  ],
+  "EndDate": [
+    1926
+  ],
+  "Gender": [
+    "Male"
+  ],
+  "Date": "1914-26",
+  "Medium": "Oil on canvas",
+  "Dimensions": "6' 6 1/2\" x 19' 7 1/2\" (199.5 x 599 cm)",
+  "CreditLine": "Mrs. Simon Guggenheim Fund",
+  "AccessionNumber": "712.1959",
+  "Classification": "Painting",
+  "Department": "Painting & Sculpture",
+  "DateAcquired": "1959-12-30",
+  "Cataloged": "Y",
+  "ObjectID": 80298,
+  "URL": "http://www.moma.org/collection/works/80298",
+  "ThumbnailURL": "http://www.moma.org/media/W1siZiIsIjI0Njc4MyJdLFsicCIsImNvbnZlcnQiLCItcmVzaXplIDMwMHgzMDBcdTAwM2UiXV0.jpg?sha=c738dc9af4324890",
+  "Height (cm)": 199.5,
+  "Width (cm)": 599.0
+},
+{
+    "Title": "Stevedores Resting",
+    "Artist": [
+      "Alfredo Guido"
+    ],
+    "ConstituentID": [
+      2400
+    ],
+    "ArtistBio": [
+      "Argentine, 1892–1967"
+    ],
+    "Nationality": [
+      "Argentine"
+    ],
+    "BeginDate": [
+      1892
+    ],
+    "EndDate": [
+      1967
+    ],
+    "Gender": [
+      "Male"
+    ],
+    "Date": "1938",
+    "Medium": "Tempera on wood",
+    "Dimensions": "21 1/8 x 18 1/8\" (53.7 x 46 cm)",
+    "CreditLine": "Inter-American Fund",
+    "AccessionNumber": "702.1942",
+    "Classification": "Painting",
+    "Department": "Painting & Sculpture",
+    "DateAcquired": "1942-12-29",
+    "Cataloged": "Y",
+    "ObjectID": 80285,
+    "URL": "http://www.moma.org/collection/works/80285",
+    "ThumbnailURL": "http://www.moma.org/media/W1siZiIsIjQzOTcwNyJdLFsicCIsImNvbnZlcnQiLCItcmVzaXplIDMwMHgzMDBcdTAwM2UiXV0.jpg?sha=a5b45edfd7099483",
+    "Height (cm)": 53.7,
+    "Width (cm)": 46.0
+  },
+  {
+    "Title": "Abra Variation I",
+    "Artist": [
+      "Frank Stella"
+    ],
+    "ConstituentID": [
+      5640
+    ],
+    "ArtistBio": [
+      "American, born 1936"
+    ],
+    "Nationality": [
+      "American"
+    ],
+    "BeginDate": [
+      1936
+    ],
+    "EndDate": [
+      0
+    ],
+    "Gender": [
+      "Male"
+    ],
+    "Date": "1969",
+    "Medium": "Fluorescent alkyd on canvas",
+    "Dimensions": "10' x 9' 11 7/8\" (304.8 x 304.5 cm)",
+    "CreditLine": "Gift of Philip Johnson in honor of William Rubin",
+    "AccessionNumber": "695.1980",
+    "Classification": "Painting",
+    "Department": "Painting & Sculpture",
+    "DateAcquired": "1980-12-09",
+    "Cataloged": "Y",
+    "ObjectID": 80273,
+    "URL": "http://www.moma.org/collection/works/80273",
+    "ThumbnailURL": "http://www.moma.org/media/W1siZiIsIjE1OTIyOSJdLFsicCIsImNvbnZlcnQiLCItcmVzaXplIDMwMHgzMDBcdTAwM2UiXV0.jpg?sha=a755f4926173251e",
+    "Height (cm)": 304.8,
+    "Width (cm)": 304.5
+  },
+  {
+    "Title": "Accident in the Air",
+    "Artist": [
+      "Anton Refregier"
+    ],
+    "ConstituentID": [
+      4845
+    ],
+    "ArtistBio": [
+      "American, born Russia. 1905–1979"
+    ],
+    "Nationality": [
+      "American"
+    ],
+    "BeginDate": [
+      1905
+    ],
+    "EndDate": [
+      1979
+    ],
+    "Gender": [
+      "Male"
+    ],
+    "Date": "1939",
+    "Medium": "Oil on board",
+    "Dimensions": "19 x 23\" (48.3 x 58.4 cm)",
+    "CreditLine": "Gift of the New York World's Fair, 1939",
+    "AccessionNumber": "641.1939",
+    "Classification": "Painting",
+    "Department": "Painting & Sculpture",
+    "DateAcquired": "1939-12-08",
+    "Cataloged": "Y",
+    "ObjectID": 80161,
+    "URL": "http://www.moma.org/collection/works/80161",
+    "ThumbnailURL": "http://www.moma.org/media/W1siZiIsIjIwOTIwNCJdLFsicCIsImNvbnZlcnQiLCItcmVzaXplIDMwMHgzMDBcdTAwM2UiXV0.jpg?sha=8699c6532a956bab",
+    "Height (cm)": 48.3,
+    "Width (cm)": 58.4
+  }

--- a/sketchy_database_0.json
+++ b/sketchy_database_0.json
@@ -1,0 +1,60 @@
+{
+    "Title": "L'Estaque",
+    "Artist": [
+      "Paul Cézanne"
+    ],
+    "ArtistBio": [
+      "French, 1839–1906"
+    ],
+    "Date": "1879-83",
+    "Medium": "Oil on canvas",
+    "URL": "http://www.moma.org/collection/works/80302"
+  },
+  {
+  "Title": "Water Lilies",
+  "Artist": [
+    "Claude Monet"
+  ],
+  "ArtistBio": [
+    "French, 1840–1926"
+  ],
+  "Date": "1914-26",
+  "Medium": "Oil on canvas",
+  "URL": "http://www.moma.org/collection/works/80298"
+},
+{
+    "Title": "Stevedores Resting",
+    "Artist": [
+      "Alfredo Guido"
+    ],
+    "ArtistBio": [
+      "Argentine, 1892–1967"
+    ],
+    "Date": "1938",
+    "Medium": "Tempera on wood",
+    "URL": "http://www.moma.org/collection/works/80285"
+  },
+  {
+    "Title": "Abra Variation I",
+    "Artist": [
+      "Frank Stella"
+    ],
+    "ArtistBio": [
+      "American, born 1936"
+    ],
+    "Date": "1969",
+    "Medium": "Fluorescent alkyd on canvas",
+    "URL": "http://www.moma.org/collection/works/80273"
+  },
+  {
+    "Title": "Accident in the Air",
+    "Artist": [
+      "Anton Refregier"
+    ],
+    "ArtistBio": [
+      "American, born Russia. 1905–1979"
+    ],
+    "Date": "1939",
+    "Medium": "Oil on board",
+    "URL": "http://www.moma.org/collection/works/80161"
+  }


### PR DESCRIPTION
Added small subset of 5 paintings to get started with the chatbot. Added two json files:
1. artworks_subset.json: Simply contains the entries and all information from MoMA collection
2. sketchy_database_0.json: Only has information that will be relevant to the chatbot